### PR TITLE
Enable multi-class support in single detector

### DIFF
--- a/examples/single_detect.py
+++ b/examples/single_detect.py
@@ -2,6 +2,7 @@ import requests
 import matplotlib.pyplot as plt
 import cv2
 import os
+import json
 
 
 if __name__ == "__main__":
@@ -16,14 +17,17 @@ if __name__ == "__main__":
     ref_img_bytes = ref_img_encoded.tobytes()
 
     data = {
-        "label": "keys",
-        "description": "car keys",
+        "labels": json.dumps(["woman", "keys"]),
+        "descriptions": json.dumps(["a woman", "car keys"]),
     }
 
     response = requests.post(
         "http://localhost:8000/single-detect?model_name=gemini-2.5-flash-preview-04-17",
         headers={"X-API-Key": "tym_razem_to_musi_poleciec"},
-        files={"file": ("image.png", img_bytes, "image/png"), "ref_file": ("ref_image.png", ref_img_bytes, "image/png")},
+        files=[
+            ("file", ("image.png", img_bytes, "image/png")),
+            ("ref_file", ("keys.png", ref_img_bytes, "image/png")),
+        ],
         data=data,
     )
     detections = response.json()
@@ -32,8 +36,12 @@ if __name__ == "__main__":
         y = int(detection["y"] * image.shape[0])
         width = int(detection["width"] * image.shape[1])
         height = int(detection["height"] * image.shape[0])
-        color = (0, 0, 255)
+        color = {
+            "woman": (0, 255, 0),
+            "keys": (255, 0, 255),
+        }[detection["label"]]
         cv2.rectangle(image, (x, y), (x + width, y + height), color, 8)
+        cv2.putText(image, detection["label"], (x, y), cv2.FONT_HERSHEY_SIMPLEX, 2, color, 8)
     plt.imshow(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
     plt.axis("off")
     plt.show()


### PR DESCRIPTION
## Summary
- use single detector iteratively for multiple classes
- allow uploading reference images per class
- update single detect example for new API

## Testing
- `python -m py_compile jemdzem/backend.py examples/single_detect.py`
- `pytest -q`